### PR TITLE
Fix unexpected keyword argument TypeError on UpnpFactory.__init__()

### DIFF
--- a/custom_components/wiim_custom/media_player.py
+++ b/custom_components/wiim_custom/media_player.py
@@ -227,7 +227,7 @@ class WiiMDevice(MediaPlayerEntity):
         self._fw_ver = '1.0.0'
         self._device_model = 'Unknown'
         requester = AiohttpRequester(UPNP_TIMEOUT)
-        self._factory = UpnpFactory(requester, disable_unknown_out_argument_error=True)
+        self._factory = UpnpFactory(requester)
         self._upnp_device = None
         self._service_transport = None
         self._service_control = None


### PR DESCRIPTION
When trying to run current `beta` branch on HA 2025.1.4 following error message appears:

```
Error while setting up wiim_custom platform for media_player
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 366, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/wiim_custom/media_player.py", line 207, in async_setup_platform
    wiim = WiiMDevice(name,
                      host,
    ...<2 lines>...
                      state,
                      hass)
  File "/config/custom_components/wiim_custom/media_player.py", line 231, in __init__
    self._factory = UpnpFactory(requester, disable_unknown_out_argument_error=True)
                    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: UpnpFactory.__init__() got an unexpected keyword argument 'disable_unknown_out_argument_error'
```

This PR removes attribute disable_unknown_out_argument_error from __init__() to prevent this.